### PR TITLE
Add `sndata` as affiliate package

### DIFF
--- a/EPs/sep_add_sndata_affil.md
+++ b/EPs/sep_add_sndata_affil.md
@@ -118,4 +118,4 @@ The Open Supernova Cataloge (OSC) provides public access to SN data from a varie
 
 ## Decision rationale
 
-<!-- To be filled in when the proposal is accepted or rejected -->
+The SNData package fills the need that sndatasets was originally trying to address. Bringing it under the sncosmo organization will enable discovery and possibly make it easier for more people to contribute.  There were no objections raised.

--- a/EPs/sep_add_sndata_affil.md
+++ b/EPs/sep_add_sndata_affil.md
@@ -7,9 +7,9 @@ date-created: 2020 May 19
 
 date-last-revised:  2020 May 19
 
-date-accepted: 
+date-accepted: 2020 Jun 04
 
-status: Discussion 
+status: Accepted 
 
 
 

--- a/EPs/sep_add_sndata_affil.md
+++ b/EPs/sep_add_sndata_affil.md
@@ -1,0 +1,121 @@
+# Add SNData as Affiliate Package
+
+
+author: Daniel Perrefort
+
+date-created: 2020 May 19
+
+date-last-revised:  2020 May 19
+
+date-accepted: 
+
+status: Discussion 
+
+
+
+## Abstract
+
+SNData provides access to data releases published by a variety of supernova (SN) surveys. It is designed to support the development of scalable analysis pipelines that translate with minimal effort between and across data sets. This SEP proposes to make SNData an SNCosmo affiliate package and is motivated by previous work undertaken by Kyle Barbary on the `sndatasets` package.
+
+
+
+
+## Detailed description
+
+A few years ago work was undertaken to build an `sncosmo` affiliated data access package called `sndatasets` ([source](https://github.com/sncosmo/sndatasets)). Work on this project has stalled and been abandoned. More recently, the `sndata` package was developed for internal use in ongoing projects at the University of Pittsburgh. This new package has been made public and recently made a v1.0 release. We here proposes to depricate `sndatasets`  and adopt  `sndata` as an official affiliate package. This would make it easier for users to get new projects up and running with `sncosmo` on real data. It would also provide a standardized but optional design for combining  `sncosmo` and data access in third pary analysis pipelines.
+
+
+
+### Package description
+
+A minimal package description is provided here. Detailed questions should refer to existing documentation on [Read The Docs](https://sn-data.readthedocs.io/en/latest/). Full examples are available in the [quick](https://sn-data.readthedocs.io/en/latest/getting_started/quick_start.html) and [slow](https://sn-data.readthedocs.io/en/latest/getting_started/slow_start.html) starts.
+
+
+
+`sndata` provides access to photometric and spectroscopic data using the following base classes:
+
+- `SpectroscopicRelease()` for parsing spectroscopic data
+- `PhotometricRelease(SpectroscopicRelease)` for parsing photometric data
+
+There are some differences between these classes, but they both support the same key functionality for downloading, parsing, and retrieving data. For example:
+
+```python
+# All data releases are available as ``sndata.<survey name>.<release name>``
+from sndata.csp import DR3
+dr3 = DR3()  # Locates data on the local machine
+
+# Download data to your machine.
+# Note: If data is already downloaded, this function call won't do anything.
+dr3.download_module_data()
+
+# Check what tables are available from the release's corresponding publication
+# and read one of those tables by referencing the table name or number
+published_tables = dr3.get_available_tables()
+dr3_demo_table = dr3.load_table(published_tables[0])
+
+# Check what objects are included in the data release
+# and read in the data for an object using it's Id
+object_ids = dr3.get_available_ids()  # A list
+demo_id = object_ids[0]
+dr3.get_data_for_id(demo_id)  # An astropy table
+
+# Data is auto-formatted to be compatible with the SNCosmo package.
+# To disable this and return data as presented on the data release,
+# set ``format_table=False``.
+dr3.get_data_for_id(demo_id, format_table=False)
+
+```
+
+Multiple data sets can also be combined into a single data access instance while maintaning the same data access UI (see more [here](https://sn-data.readthedocs.io/en/latest/getting_started/combining_datasets.html)):
+
+```python
+ from sndata import CombinedDataset, csp, des
+
+ combined_data = CombinedDataset(csp.DR3(), des.SN3YR())
+```
+
+
+
+
+
+
+## Branches and pull requests
+
+Existing source code for SNData can be found [on GitHub](https://github.com/mwvgroup/sndata)
+
+Existing documentation can be found on [Read The Docs](https://sn-data.readthedocs.io/en/latest/)
+
+
+
+## Implementation
+
+SNData is already on a 1.n release. Changes to make it an affiliated package are minimal:
+
+- Move SNData into the sncosmo GitHub organization
+- Officially depricate the `sndatasets` project
+- Add some additional compatibility tests (this is mostly done)
+- Use SNData to handle the loading of `sncosmo` example data
+- Various doc updates listing explicit support between the packages.
+- **optional:** SNData downloads data from the servers / websites of individual surveys. If we want to make this an affiliate package, thought should be given to whether we want to use a centralized server (e.g. zenodo) to provide improved uptime.
+- **optional:** Work is ongoing to add the LOSS, BSNIP, and Sweetspot surveys to SNData. It would be nice to resume / finish adding these data sets as part of this SEP.
+
+
+
+
+## Backward compatibility
+
+SNData is **NOT** compatibale with Python2.
+
+
+
+
+## Alternatives
+
+The Open Supernova Cataloge (OSC) provides public access to SN data from a variety of surveys. However, it provides limited utilities for accessing or parsing the data beyond a RESTFUL API. The OSC also does not include transmission curves or survey data (e.g. tables from the data release paper). This limits OSC's primary use to being a data aquisition tool and leaves users to build their tools for downloading and parsing data.
+
+
+
+
+## Decision rationale
+
+<!-- To be filled in when the proposal is accepted or rejected -->

--- a/EPs/sep_add_sndata_affil.md
+++ b/EPs/sep_add_sndata_affil.md
@@ -66,7 +66,7 @@ dr3.get_data_for_id(demo_id, format_table=False)
 
 ```
 
-Multiple data sets can also be combined into a single data access instance while maintaning the same data access UI (see more [here](https://sn-data.readthedocs.io/en/latest/getting_started/combining_datasets.html)):
+Multiple data sets can also be combined into a single data access instance while maintaning the same data access UI demonstrated above (see more [here](https://sn-data.readthedocs.io/en/latest/getting_started/combining_datasets.html)):
 
 ```python
  from sndata import CombinedDataset, csp, des

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ rejected, or tabled for further discussion later.
 
 | #    | Title                                                        | Date        |
 | ---- | :----------------------------------------------------------- | ----------- |
-| 1    | [Add \`sndata\` as affiliate package](https://github.com/sncosmo/sncosmo-eps/pull/4) | 2020-Jun-04 |
+| 1    | [Add \`sndata\` as affiliate package](EPs/sep_add_sndata_affil.md) | 2020-Jun-04 |
 
 ## Proposing a new EPs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SNCosmo Enhancement Proposals
- 
+
 EPs are documents to address non-trivial enhancements that require discussion and thought 
 beyond a single Pull Request. This is intended to mirror the long-standing Python Enhancement 
 Proposal process and Astropy's Proposals for Enhancement, but generally not quite as
@@ -10,18 +10,18 @@ rejected, or tabled for further discussion later.
 
 ## Accepted EPs
 
-| # |     Title                          | Date        |
-|---|:-----------------------------------|-------------|
-| 1 | [`Title`](url)                     | 2020-FEB-XX |
- 
+| #    | Title                                                        | Date        |
+| ---- | :----------------------------------------------------------- | ----------- |
+| 1    | [Add \`sndata\` as affiliate package](https://github.com/sncosmo/sncosmo-eps/pull/4) | 2020-Jun-04 |
+
 ## Proposing a new EPs
- 
+
 New EPs should be created using the `sep-template.md` file in this repository. Fork the repository, 
 copy `sep_template.md` to `EPs/sep_<some_working_name>.md` and issue a Pull Request with that file 
 once you've written it up. Little explanation is required in the PR itself given that the document 
 has all the content - usually it's easiest to just paste in the abstract. The EP number will be 
 assigned once it is accepted.
- 
+
 Note that there is not much point to making proposals unless someone or some group has signed up to 
 implement it if the EP is accepted (typically this would involve the author or authors of the EP). 
 Just issuing an EP in order to spur others to do work is not generally going to be received well. 
@@ -29,14 +29,14 @@ Generally, an implementation is expected before an EP can be considered fully ac
 that require extensive work that few are willing to perform without some assurance it will be accepted, 
 provisional acceptance is an option. For serious consideration it is usually good to show that detailed 
 technical aspects have been played with in real code rather (even if it isn't a complete implementation).
- 
- 
+
+
 ## Finalizing EPs
- 
+
 The final decision on accepting, rejecting, or tabling an EPs lies with [Kyle Barbary](https://github.com/kbarbary). 
 Once the community discussion on the EP has wound down, Kyle makes the
 final decision on acceptance, rejection, or defering action. One of the community members should then:
- 
+
 1. Fill in the "Decision rationale" section of the EP with a description of why
    the EP was accepted, rejected or tabled, including a summary of the community's
    discussion as relevant.
@@ -52,14 +52,14 @@ final decision on acceptance, rejection, or defering action. One of the communit
    corresponding Markdown link refs for the new EP. Preview
    the update and test the links to make sure they are all correct. Then commit
    directly to master (or PR if you prefer).
- 
- 
+
+
 ## Updating EPs
- 
+
 In the cases where an updated EP requires updating (e.g. references to a new EP that 
 supercedes it, clarifying information that emerges after the EP is accepted, etc.), changes 
 can be made directly via PR, but the "date-last-revised" should be updated in the EP.
- 
- 
+
+
 This procedure was adapted from the [Astropy Proposals for Enhancement](https://github.com/astropy/astropy-APEs)
 process.


### PR DESCRIPTION
SNData provides access to data releases published by a variety of supernova (SN) surveys. It is designed to support the development of scalable analysis pipelines that translate with minimal effort between and across data sets. This SEP proposes to make SNData an SNCosmo affiliate package and is motivated by previous work undertaken by Kyle Barbary on the `sndatasets` package.